### PR TITLE
Track "last key" in scanner

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -234,6 +234,7 @@ func (r *Reader) GetBlockBuf(i int, dst []byte) ([]byte, error) {
 	case CompressionNone:
 		dst = r.mmap[block.offset : block.offset+uint64(block.size)]
 	case CompressionSnappy:
+		// TODO(davidt): do we sometimes split blocks into sub-blocks?
 		uncompressedByteSize := binary.BigEndian.Uint32(r.mmap[block.offset : block.offset+4])
 		if uncompressedByteSize != block.size {
 			return nil, errors.New("mismatched uncompressed block size")

--- a/scanner.go
+++ b/scanner.go
@@ -16,6 +16,8 @@ type Scanner struct {
 	pos    *int
 	buf    []byte
 
+	lastKey []byte // this is NOT supposed to be useful for anything other than negatives. see GetFirst.
+
 	// When off, maybe be faster but may return incorrect results rather than error on out-of-order keys.
 	EnforceKeyOrder bool
 	OrderedOps
@@ -26,13 +28,14 @@ func NewScanner(r *Reader) *Scanner {
 	if r.compressionCodec > CompressionNone {
 		buf = make([]byte, int(float64(r.totalUncompressedDataBytes/uint64(len(r.index)))*1.5))
 	}
-	return &Scanner{r, 0, nil, nil, buf, true, OrderedOps{nil}}
+	return &Scanner{r, 0, nil, nil, buf, nil, true, OrderedOps{nil}}
 }
 
 func (s *Scanner) Reset() {
 	s.idx = 0
 	s.block = nil
 	s.pos = nil
+	s.lastKey = nil
 	s.ResetState()
 }
 
@@ -94,6 +97,9 @@ func (s *Scanner) blockFor(key []byte) ([]byte, error, bool) {
 }
 
 func (s *Scanner) GetFirst(key []byte) ([]byte, error, bool) {
+	if s.lastKey != nil && After(s.lastKey, key) {
+		return nil, nil, false
+	}
 	data, err, ok := s.blockFor(key)
 
 	if !ok {
@@ -114,6 +120,9 @@ func (s *Scanner) GetFirst(key []byte) ([]byte, error, bool) {
 }
 
 func (s *Scanner) GetAll(key []byte) ([][]byte, error) {
+	if s.lastKey != nil && After(s.lastKey, key) {
+		return nil, nil
+	}
 	data, err, ok := s.blockFor(key)
 
 	if !ok {
@@ -153,11 +162,13 @@ func (s *Scanner) getValuesFromBuffer(buf []byte, pos *int, key []byte, first bo
 
 			if first {
 				*pos = i
+				s.lastKey = buf[i+8 : i+8+keyLen]
 				return ret, nil, true
 			}
 			acc = append(acc, ret)
 		case cmp > 0:
 			*pos = i
+			s.lastKey = buf[i+8 : i+8+keyLen]
 			return nil, acc, len(acc) > 0
 		default:
 			i += 8 + keyLen + valLen
@@ -165,6 +176,11 @@ func (s *Scanner) getValuesFromBuffer(buf []byte, pos *int, key []byte, first bo
 	}
 
 	*pos = i
+	if len(s.reader.index) > s.idx+1 {
+		s.lastKey = s.reader.index[s.idx+1].firstKeyBytes
+	} else {
+		s.lastKey = nil
+	}
 
 	if s.reader.Debug {
 		log.Printf("[Scanner.getValuesFromBuffer] walked off block\n")

--- a/scanner.go
+++ b/scanner.go
@@ -44,6 +44,7 @@ func (s *Scanner) blockFor(key []byte) ([]byte, error, bool) {
 		}
 	}
 
+	// TODO(davidt): can we use pos?
 	if s.reader.index[s.idx].IsAfter(key) {
 		if s.reader.Debug {
 			log.Printf("[Scanner.blockFor] curBlock after key %s (cur: %d, start: %s)\n",


### PR DESCRIPTION
LastKey is _usually_ the key at the current offset or may be the next one.
The only strict invariant though is that, until reset, a scanner will not find a key less than lastKey, meaning that get can use it to short circuit.
