### PR TITLE
Rewrite writer_test.go to use testify

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2,9 +2,20 @@ package hfile
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func compareBytes(a, e []byte) bool {
+	b := bytes.Equal(a, e)
+	if !b {
+		fmt.Sprintf("'%v', expected '%v'\n", a, e)
+	}
+	return b
+}
 
 func TestIterator(t *testing.T) {
 	f, r := fakeDataReader(t, true, false)
@@ -12,64 +23,36 @@ func TestIterator(t *testing.T) {
 	i := r.GetIterator()
 	ok, err := i.Next()
 
-	if err != nil {
-		t.Fatal("error in next:", err)
-	}
-	if !ok {
-		t.Fatal("next is not true")
-	}
+	assert.Nil(t, err, "error creating tempfile:", err)
+	assert.True(t, ok, "next is not true")
 
-	if !bytes.Equal(i.Key(), MockKeyInt(0)) {
-		t.Fatalf("'%v', expected '%v'\n", i.Key(), MockKeyInt(0))
-	}
-	if !bytes.Equal(i.Value(), MockValueInt(0)) {
-		t.Fatalf("'%v', expected '%v'\n", i.Value(), MockValueInt(0))
-	}
+	assert.True(t, compareBytes(i.Key(), MockKeyInt(0)))
+
+	assert.True(t, compareBytes(i.Value(), MockValueInt(0)))
 
 	ok, err = i.Next()
-	if err != nil {
-		t.Fatal("error in next:", err)
-	}
-	if !ok {
-		t.Fatal("next is not true")
-	}
+	assert.Nil(t, err, "error creating tempfile:", err)
+	assert.True(t, ok, "next is not true")
 
-	if !bytes.Equal(i.Key(), MockKeyInt(1)) {
-		t.Fatalf("'%v', expected '%v'\n", i.Key(), MockKeyInt(1))
-	}
-	if !bytes.Equal(i.Value(), MockValueInt(1)) {
-		t.Fatalf("'%v', expected '%v'\n", i.Value(), MockValueInt(1))
-	}
+	assert.True(t, compareBytes(i.Key(), MockKeyInt(1)))
+
+	assert.True(t, compareBytes(i.Value(), MockValueInt(1)))
 
 	ok, err = i.Seek(MockKeyInt(65537))
-	if err != nil {
-		t.Fatal("error in seek:", err)
-	}
-	if !ok {
-		t.Fatal("seek is not true")
-	}
+	assert.Nil(t, err, "error creating tempfile:", err)
+	assert.True(t, ok, "next is not true")
 
-	if !bytes.Equal(i.Key(), MockKeyInt(65537)) {
-		t.Fatalf("'%v', expected '%v'\n", i.Key(), MockKeyInt(65537))
-	}
-	if !bytes.Equal(i.Value(), MockValueInt(65537)) {
-		t.Fatalf("'%v', expected '%v'\n", i.Value(), MockValueInt(65537))
-	}
+	assert.True(t, compareBytes(i.Key(), MockKeyInt(65537)))
+
+	assert.True(t, compareBytes(i.Value(), MockValueInt(65537)))
 
 	ok, err = i.Seek(MockKeyInt(75537))
-	if err != nil {
-		t.Fatal("error in seek:", err)
-	}
-	if !ok {
-		t.Fatal("seek is not true")
-	}
+	assert.Nil(t, err, "error creating tempfile:", err)
+	assert.True(t, ok, "next is not true")
 
-	if !bytes.Equal(i.Key(), MockKeyInt(75537)) {
-		t.Fatalf("'%v', expected '%v'\n", i.Key(), MockKeyInt(75537))
-	}
-	if !bytes.Equal(i.Value(), MockValueInt(75537)) {
-		t.Fatalf("'%v', expected '%v'\n", i.Value(), MockValueInt(75537))
-	}
+	assert.True(t, compareBytes(i.Key(), MockKeyInt(75537)))
+
+	assert.True(t, compareBytes(i.Value(), MockValueInt(75537)))
 }
 
 func TestSinglePrefix(t *testing.T) {
@@ -78,54 +61,32 @@ func TestSinglePrefix(t *testing.T) {
 	i := r.GetIterator()
 
 	res, err := i.AllForPrefixes([][]byte{[]byte{0, 0, 1}})
-	if err != nil {
-		t.Fatal("error finding all for prefixes:", err)
-	}
+	assert.Nil(t, err, "error finding all for prefixes:", err)
 
-	if len(res) != 256 {
-		t.Fatalf("Wrong number of matched keys: %d instead of %d", len(res), 256)
-	}
+	assert.Len(t, res, 256, "Wrong number of matched keys")
 
 	k := string(MockKeyInt(511))
-	if v, ok := res[k]; !ok {
-		t.Fatalf("Key %v not in res %v", k, res)
-	} else {
-		if len(v) != 1 {
-			t.Fatalf("Wrong number of results for ~511: %d (%v)", len(v), v)
-		}
-		if !bytes.Equal(v[0], MockValueInt(511)) {
-			t.Fatal("bad value:", v[0])
-		}
-	}
+	v, ok := res[k]
+	assert.True(t, ok, fmt.Sprintf("Key %v not in res %v", k, res))
+	assert.Len(t, v, 1, "Wrong number of results for ~511")
+	assert.True(t, compareBytes(v[0], MockValueInt(511)))
 
 	k = string(MockKeyInt(256))
-	if v, ok := res[k]; !ok {
-		t.Fatalf("Key %v not in res %v", k, res)
-	} else {
-		if len(v) != 1 {
-			t.Fatalf("Wrong number of results for ~256: %d (%v)", len(v), v)
-		}
-		if !bytes.Equal(v[0], MockValueInt(256)) {
-			t.Fatalf("bad value: %s vs %s", v[0], MockValueInt(256))
-		}
-	}
+	v, ok = res[k]
+	assert.True(t, ok, fmt.Sprintf("Key %v not in res %v", k, res))
+	assert.Len(t, v, 1, "Wrong number of results for ~256")
+	assert.True(t, compareBytes(v[0], MockValueInt(256)))
 
 	k = string([]byte{0, 0, 0, 255})
-	if _, ok := res[k]; ok {
-		t.Fatalf("Key %v should not be in res %v", k, res)
-	}
+	_, ok = res[k]
+	assert.False(t, ok, fmt.Sprintf("Key %v should not be in res %v", k, res))
 
 	k = string([]byte{0, 0, 2, 0})
-	if _, ok := res[k]; ok {
-		t.Fatalf("Key %v should not be in res %v", k, res)
-	}
+	_, ok = res[k]
+	assert.False(t, ok, fmt.Sprintf("Key %v should not be in res %v", k, res))
 
 	k = string([]byte{0, 0, 1, 30})
-	if v, ok := res[k]; !ok {
-		t.Fatalf("Key %v not in res %v", k, res)
-	} else {
-		if !bytes.Equal(v[0], MockValueInt(286)) {
-			t.Fatal("bad value:", v[0], MockValueInt(286))
-		}
-	}
+	v, ok = res[k]
+	assert.True(t, ok, fmt.Sprintf("Key %v not in res %v", k, res))
+	assert.True(t, compareBytes(v[0], MockValueInt(286)))
 }

--- a/lru/lru_test.go
+++ b/lru/lru_test.go
@@ -2,6 +2,8 @@ package lru
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLRU(t *testing.T) {
@@ -12,36 +14,29 @@ func TestLRU(t *testing.T) {
 
 	lru := NewLRU(3)
 
-	if _, ok := lru.Get(1); ok {
-		t.Fatal("empty lru should return nothing")
-	}
+	_, ok := lru.Get(1)
+	assert.False(t, ok, "empty lru should return nothing")
 
 	lru.Add(1, b1)
-	if _, ok := lru.Get(1); !ok {
-		t.Fatal("missing only item")
-	}
+
+	_, ok = lru.Get(1)
+	assert.True(t, ok, "missing only item")
 
 	lru.Add(2, b2)
 	lru.Add(3, b3)
 
-	if _, ok := lru.Get(1); !ok {
-		t.Fatal("missing 1")
-	}
-	if _, ok := lru.Get(2); !ok {
-		t.Fatal("missing 2")
-	}
-	if _, ok := lru.Get(3); !ok {
-		t.Fatal("missing 3")
-	}
-	if _, ok := lru.Get(4); ok {
-		t.Fatal("phantom item")
-	}
-	lru.Add(4, b4)
-	if _, ok := lru.Get(1); ok {
-		t.Fatal("phantom item")
-	}
-	if _, ok := lru.Get(4); !ok {
-		t.Fatal("item!")
-	}
+	_, ok = lru.Get(1)
+	assert.True(t, ok, "missing only item")
+	_, ok = lru.Get(2)
+	assert.True(t, ok, "missing only item")
+	_, ok = lru.Get(3)
+	assert.True(t, ok, "missing only item")
+	_, ok = lru.Get(4)
+	assert.False(t, ok, "phantom item")
 
+	lru.Add(4, b4)
+	_, ok = lru.Get(1)
+	assert.False(t, ok, "phantom item")
+	_, ok = lru.Get(4)
+	assert.True(t, ok, "missing item 4")
 }

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -2,12 +2,15 @@ package hfile
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-// The sample file `smaple/pairs.hfile` has pairs of integers to strings.
+// The sample file `sample/pairs.hfile` has pairs of integers to strings.
 // It was generated from the "known-good" scala ver
 // The keys are sequential integers represented as 4 bytes (big-endian).
 // The values are strings, containing ascii bytes of the string "~x", where x is the key's integer value.
@@ -19,39 +22,29 @@ var secondSampleBlockKey = []byte{0, 0, 229, 248}
 
 func fakeDataReader(t *testing.T, compress, multi bool) (string, *Reader) {
 	f, err := ioutil.TempFile("", "hfile")
-	if err != nil {
-		t.Fatal("cannot create tempfile: ", err)
-	}
+	assert.Nil(t, err, "error creating tempfile:", err)
+
 	if multi {
 		err = GenerateMockMultiHfile(f.Name(), 100000, 1024*4, compress, false, false)
-		if err != nil {
-			t.Fatal("cannot write to tempfile: ", err)
-		}
+		assert.Nil(t, err, "cannot write to tempfile: ", err)
 	} else {
 		err = GenerateMockHfile(f.Name(), 100000, 1024*4, compress, false, false)
-		if err != nil {
-			t.Fatal("cannot write to tempfile: ", err)
-		}
+		assert.Nil(t, err, "cannot write to tempfile: ", err)
 	}
 	reader, err := NewReader("sample", f.Name(), false, testing.Verbose())
-	if err != nil {
-		t.Fatal("error creating reader:", err)
-	}
+	assert.Nil(t, err, "error creating reader:", err)
 	return f.Name(), reader
 }
 
 func TestFirstKeys(t *testing.T) {
 	r, err := NewReader("sample", "testdata/pairs.hfile", false, testing.Verbose())
-	if err != nil {
-		t.Fatal("cannot open sample: ", err)
-	}
+	assert.Nil(t, err, "cannot open sample: ", err)
 
-	if !bytes.Equal(r.index[0].firstKeyBytes, firstSampleKey) {
-		t.Fatalf("'%v', expected '%v'\n", r.index[0].firstKeyBytes, firstSampleKey)
-	}
-	if !bytes.Equal(r.index[1].firstKeyBytes, secondSampleBlockKey) {
-		t.Fatalf("'%v', expected '%v'\n", r.index[1].firstKeyBytes, secondSampleBlockKey)
-	}
+	assert.True(t, bytes.Equal(r.index[0].firstKeyBytes, firstSampleKey),
+		fmt.Sprintf("'%v', expected '%v'\n", r.index[0].firstKeyBytes, firstSampleKey))
+
+	assert.True(t, bytes.Equal(r.index[1].firstKeyBytes, secondSampleBlockKey),
+		fmt.Sprintf("'%v', expected '%v'\n", r.index[1].firstKeyBytes, secondSampleBlockKey))
 }
 
 func TestGetFirstSample(t *testing.T) {
@@ -63,34 +56,25 @@ func TestGetFirstSample(t *testing.T) {
 	var err error
 
 	first, err, _ = s.GetFirst(MockKeyInt(1))
-	if err != nil {
-		t.Fatal("error finding key:", err)
-	}
-	if !bytes.Equal(first, MockValueInt(1)) {
-		t.Fatalf("'%v', expected '%v'\n", first, MockValueInt(1))
-	}
+	assert.Nil(t, err, "error finding key:", err)
+	assert.True(t, bytes.Equal(first, MockValueInt(1)),
+		fmt.Sprintf("'%v', expected '%v'\n", first, MockValueInt(1)))
 
 	second, err, _ = s.GetFirst(MockKeyInt(1000))
-	if err != nil {
-		t.Fatal("error finding key:", err)
-	}
-	if !bytes.Equal(second, MockValueInt(1000)) {
-		t.Fatalf("'%v', expected '%v'\n", second, MockValueInt(1000))
-	}
-	if !bytes.Equal(first, MockValueInt(1)) {
-		t.Fatalf("First value CHANGED '%v', expected '%v'\n", first, MockValueInt(1))
-	}
+	assert.Nil(t, err, "error finding key:", err)
+	assert.True(t, bytes.Equal(second, MockValueInt(1000)),
+		fmt.Sprintf("'%v', expected '%v'\n", second, MockValueInt(1000)))
+
+	assert.True(t, bytes.Equal(first, MockValueInt(1)),
+		fmt.Sprintf("First value CHANGED '%v', expected '%v'\n", first, MockValueInt(1)))
 
 	second, err, _ = s.GetFirst(MockKeyInt(65547))
-	if err != nil {
-		t.Fatal("error finding key:", err)
-	}
-	if !bytes.Equal(second, MockValueInt(65547)) {
-		t.Fatalf("'%v', expected '%v'\n", second, MockValueInt(65547))
-	}
-	if !bytes.Equal(first, MockValueInt(1)) {
-		t.Fatalf("First value CHANGED '%v', expected '%v'\n", first, MockValueInt(1))
-	}
+	assert.Nil(t, err, "error finding key:", err)
+	assert.True(t, bytes.Equal(second, MockValueInt(65547)),
+		fmt.Sprintf("'%v', expected '%v'\n", second, MockValueInt(65547)))
+
+	assert.True(t, bytes.Equal(first, MockValueInt(1)),
+		fmt.Sprintf("First value CHANGED '%v', expected '%v'\n", first, MockValueInt(1)))
 }
 
 func TestMulti(t *testing.T) {
@@ -103,48 +87,40 @@ func TestMulti(t *testing.T) {
 	var err error
 
 	first, err = s.GetAll(MockKeyInt(1))
-	if len(first) != 3 {
-		t.Fatalf("wrong number of values for 1: %d", len(first))
-	}
-	if err != nil {
-		t.Fatal("error finding key:", err)
-	}
-	if !bytes.Equal(first[0], expectedFirst) {
-		t.Fatalf("'%v', expected '%v'\n", first[0], expectedFirst)
-	}
+	assert.Nil(t, err, "error finding key:", err)
+	assert.Len(t, first, 3,
+		fmt.Sprintf("wrong number of values for 1: %d", len(first)))
+
+	assert.True(t, bytes.Equal(first[0], expectedFirst),
+		fmt.Sprintf("'%v', expected '%v'\n", first[0], expectedFirst))
 
 	second, err = s.GetAll(MockKeyInt(1000))
-	if err != nil {
-		t.Fatal("error finding key:", err)
-	}
-	if actual := len(second); actual != 1 {
-		t.Fatalf("wrong number of values for 1000: %d", actual)
-	}
-	if expected := MockValueInt(1000); !bytes.Equal(second[0], expected) {
-		t.Fatalf("'%s', expected '%s'\n", second[0], expected)
-	}
+	assert.Nil(t, err, "error finding key:", err)
 
-	if !bytes.Equal(first[0], expectedFirst) {
-		t.Fatalf("First value CHANGED '%v', expected '%v'\n", first[0], expectedFirst)
-	}
+	assert.Equal(t, len(second), 1, "wrong number of values for 1000")
+
+	expected := MockValueInt(1000)
+	assert.True(t, bytes.Equal(second[0], expected),
+		fmt.Sprintf("'%v', expected '%v'\n", second[0], expected))
+
+	assert.True(t, bytes.Equal(first[0], expectedFirst),
+		fmt.Sprintf("First value CHANGED '%v', expected '%v'\n", first[0], expectedFirst))
 
 	second, err = s.GetAll(MockKeyInt(1001))
-	if err != nil {
-		t.Fatal("error finding key:", err)
-	}
-	if actual := len(second); actual != 3 {
-		t.Fatalf("wrong number of values for 1001: %d", actual)
-	}
-	if expected, actual := MockMultiValueInt(1001, 0), second[0]; !bytes.Equal(actual, expected) {
-		t.Fatalf("'%v', expected '%v'\n", actual, expected)
-	}
-	if expected, actual := MockMultiValueInt(1001, 1), second[1]; !bytes.Equal(actual, expected) {
-		t.Fatalf("'%v', expected '%v'\n", actual, expected)
-	}
-	if expected, actual := MockMultiValueInt(1001, 2), second[2]; !bytes.Equal(actual, expected) {
-		t.Fatalf("'%v', expected '%v'\n", actual, expected)
-	}
-	if !bytes.Equal(first[0], expectedFirst) {
-		t.Fatalf("First value CHANGED '%v', expected '%v'\n", first[0], expectedFirst)
-	}
+	assert.Nil(t, err, "error finding key:", err)
+
+	assert.Equal(t, len(second), 3, "wrong number of values for 1001")
+
+	expected, actual := MockMultiValueInt(1001, 0), second[0]
+
+	assert.True(t, bytes.Equal(actual, expected),
+		fmt.Sprintf("'%v', expected '%v'\n", actual, expected))
+
+	expected, actual = MockMultiValueInt(1001, 2), second[2]
+
+	assert.True(t, bytes.Equal(first[0], expectedFirst),
+		fmt.Sprintf("'%v', expected '%v'\n", actual, expected))
+
+	assert.True(t, bytes.Equal(first[0], expectedFirst),
+		fmt.Sprintf("First value CHANGED '%v', expected '%v'\n", first[0], expectedFirst))
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -6,26 +6,25 @@ import (
 	"log"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func tempHfile(t *testing.T, compress bool, blockSize int, keys [][]byte, values [][]byte) (string, *Scanner) {
 	fp, err := ioutil.TempFile("", "demohfile")
-	if err != nil {
-		t.Fatal("error creating tempfile:", err)
-	}
+	assert.Nil(t, err, "error creating tempfile:", err)
+
 	if testing.Verbose() {
 		log.Println("###############")
 		log.Println("Writing temp hfile:", fp.Name())
 		log.Println("###############")
 	}
 	w, err := NewWriter(fp, compress, blockSize, testing.Verbose())
-	if err != nil {
-		t.Fatal("error creating writer:", err)
-	}
+	assert.Nil(t, err, "error creating writer:", err)
+
 	for i, _ := range keys {
-		if err := w.Write(keys[i], values[i]); err != nil {
-			t.Fatal("error writing k-v pair:", err)
-		}
+		err := w.Write(keys[i], values[i])
+		assert.Nil(t, err, "error writing k-v pair:", err)
 	}
 	w.Close()
 
@@ -36,9 +35,8 @@ func tempHfile(t *testing.T, compress bool, blockSize int, keys [][]byte, values
 	}
 
 	r, err := NewReader("demo", fp.Name(), false, testing.Verbose())
-	if err != nil {
-		t.Fatal("error creating reader:", err)
-	}
+	assert.Nil(t, err, "error creating reader:", err)
+
 	s := NewScanner(r)
 
 	return fp.Name(), s
@@ -60,22 +58,14 @@ func TestRoundTrip(t *testing.T) {
 	defer os.Remove(f)
 
 	v, err, found := s.GetFirst(keyI(3))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !found {
-		t.Fatal("not found")
-	}
-	if !bytes.Equal(v, valI(3)) {
-		t.Fatal("bad value", v)
-	}
+	assert.Nil(t, err, err)
+	assert.True(t, found, "not found")
+
+	assert.True(t, bytes.Equal(v, valI(3)), "bad value", v, valI(3))
+
 	v, err, found = s.GetFirst(keyI(5))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if found {
-		t.Fatal("missing key should not have been found.")
-	}
+	assert.Nil(t, err, err)
+	assert.False(t, found, "missing key should not have been found.")
 }
 
 func TestRoundTripCompressed(t *testing.T) {
@@ -86,22 +76,14 @@ func TestRoundTripCompressed(t *testing.T) {
 	defer os.Remove(f)
 
 	v, err, found := s.GetFirst(keyI(3))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !found {
-		t.Fatal("not found")
-	}
-	if !bytes.Equal(v, valI(3)) {
-		t.Fatal("bad value", v)
-	}
+	assert.Nil(t, err, err)
+	assert.True(t, found, "not found")
+
+	assert.True(t, bytes.Equal(v, valI(3)), "bad value", v, valI(3))
+
 	v, err, found = s.GetFirst(keyI(5))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if found {
-		t.Fatal("missing key should not have been found.")
-	}
+	assert.Nil(t, err, err)
+	assert.False(t, found, "missing key should not have been found.")
 }
 
 func TestMultiValueRoundTripCompressed(t *testing.T) {
@@ -112,34 +94,20 @@ func TestMultiValueRoundTripCompressed(t *testing.T) {
 	defer os.Remove(f)
 
 	v, err := s.GetAll(keyI(30))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(v) != 3 {
-		t.Fatal("wrong number of values for key 30", len(v))
-	}
-	if !bytes.Equal(v[1], valI(31)) {
-		t.Fatal("bad value for key 30 (1)", v[1])
-	}
+	assert.Nil(t, err, err)
+	assert.Len(t, v, 3, "wrong number of values for key 30", len(v))
+
+	assert.True(t, bytes.Equal(v[1], valI(31)), "bad value for key 30 (1)", v[1], valI(31))
 
 	v, err = s.GetAll(keyI(40))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(v) != 1 {
-		t.Fatal("wrong number of results for key 40", len(v))
-	}
-	if !bytes.Equal(v[0], valI(40)) {
-		t.Fatal("bad value for key 40", v[0])
-	}
+	assert.Nil(t, err, err)
+	assert.Len(t, v, 1, "wrong number of results for key 40", len(v))
+
+	assert.True(t, bytes.Equal(v[0], valI(40)), "bad value for key 40", v[0], valI(40))
 
 	v, err = s.GetAll(keyI(50))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(v) > 0 {
-		t.Fatal("should not find missing keys")
-	}
+	assert.Nil(t, err, err)
+	assert.Len(t, v, 0, "should not find missing keys")
 }
 
 func TestBigRoundTripCompressed(t *testing.T) {
@@ -155,13 +123,7 @@ func TestBigRoundTripCompressed(t *testing.T) {
 	defer os.Remove(f)
 
 	v, err, found := s.GetFirst(keyI(501))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !found {
-		t.Fatal("not found")
-	}
-	if !bytes.Equal(v, valI(501)) {
-		t.Fatal("bad value")
-	}
+	assert.Nil(t, err, err)
+	assert.True(t, found, "not found")
+	assert.True(t, bytes.Equal(v, valI(501)), "bad value", v, valI(501))
 }


### PR DESCRIPTION
First tests to get redone are the writer tests. I'll modify the other ones
later. I'm sure we could better use testify's other methods, but this was
a fairly straight port.

Background: "testing" was becoming too cumbersome with the if { Fatal
} business. While there are some other interesting frameworks, testify is fairly
simple and similar to what we have.