### PR TITLE
support reading to heap on startup vs mlock

### DIFF
--- a/cmd/hfileinfo/summary.go
+++ b/cmd/hfileinfo/summary.go
@@ -14,7 +14,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	if r, err := hfile.NewReader(os.Args[1], os.Args[1], false, true); err != nil {
+	if r, err := hfile.NewReader(os.Args[1], os.Args[1], hfile.OnDisk, true); err != nil {
 		log.Fatal(err)
 	} else {
 		r.PrintDebugInfo(os.Stdout, 10)

--- a/collections.go
+++ b/collections.go
@@ -13,6 +13,14 @@ import (
 	"strings"
 )
 
+type LoadMethod int
+
+const (
+	CopiedToMem LoadMethod = iota
+	MemlockFile
+	OnDisk
+)
+
 type CollectionConfig struct {
 	// The Name of the collection.
 	Name string
@@ -24,7 +32,7 @@ type CollectionConfig struct {
 	LocalPath string
 
 	// If the collection data should be kept in-memory (via mlock).
-	InMem bool
+	LoadMethod LoadMethod
 
 	// Should operations on this collection emit verbose debug output.
 	Debug bool

--- a/load-file.go
+++ b/load-file.go
@@ -1,0 +1,60 @@
+package hfile
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/edsrzf/mmap-go"
+)
+
+func loadFile(name, path string, method LoadMethod) ([]byte, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+
+	if err != nil {
+		return nil, fmt.Errorf("[Reader] Error opening file (%s): %v", path, err)
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	sizeMb := float64(fi.Size()) / (1024.0 * 1024.0)
+
+	var mapped mmap.MMap
+	if method != CopiedToMem {
+		mapped, err = mmap.Map(f, mmap.RDONLY, 0)
+
+		if err != nil {
+			log.Printf("[Reader.NewReader] Error mapping %s: %s\n", name, err.Error())
+			return nil, err
+		}
+	}
+
+	switch method {
+
+	case OnDisk:
+		log.Printf("[Reader.NewReader] Serving %s from disk...\n", name)
+
+	case MemlockFile:
+		log.Printf("[Reader.NewReader] Locking %s (%.02fmb)...\n", name, sizeMb)
+		if err = mapped.Lock(); err != nil {
+			log.Printf("[Reader.NewReader] Error locking %s: %s\n", name, err.Error())
+			return nil, err
+		}
+		log.Printf("[Reader.NewReader] Locked %s.\n", name)
+
+	case CopiedToMem:
+		log.Printf("[Reader.NewReader] Reading in %s (%.02fmb)...\n", name, sizeMb)
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			log.Printf("[Reader.NewReader] Error reading in %s: %s\n", name, err.Error())
+			return nil, err
+		}
+		log.Printf("[Reader.NewReader] Loaded %s.\n", name)
+		return data, nil
+
+	}
+	return mapped, nil
+}

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -31,13 +31,13 @@ func fakeDataReader(t *testing.T, compress, multi bool) (string, *Reader) {
 		err = GenerateMockHfile(f.Name(), 100000, 1024*4, compress, false, false)
 		assert.Nil(t, err, "cannot write to tempfile: ", err)
 	}
-	reader, err := NewReader("sample", f.Name(), false, testing.Verbose())
+	reader, err := NewReader("sample", f.Name(), CopiedToMem, testing.Verbose())
 	assert.Nil(t, err, "error creating reader:", err)
 	return f.Name(), reader
 }
 
 func TestFirstKeys(t *testing.T) {
-	r, err := NewReader("sample", "testdata/pairs.hfile", false, testing.Verbose())
+	r, err := NewReader("sample", "testdata/pairs.hfile", CopiedToMem, testing.Verbose())
 	assert.Nil(t, err, "cannot open sample: ", err)
 
 	assert.True(t, bytes.Equal(r.index[0].firstKeyBytes, firstSampleKey),

--- a/testdata.go
+++ b/testdata.go
@@ -65,7 +65,7 @@ func WriteMockIntPairs(w *Writer, keyCount int, progress bool, multi bool) error
 	return nil
 }
 
-func TestdataCollectionSet(name string, count int, compress, lock bool) (*CollectionSet, error) {
+func TestdataCollectionSet(name string, count int, compress bool, load LoadMethod) (*CollectionSet, error) {
 	path := fmt.Sprintf("testdata/%s.%d.hfile", name, count)
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		err = GenerateMockHfile(path, count, 4098, compress, false, false)
@@ -77,5 +77,5 @@ func TestdataCollectionSet(name string, count int, compress, lock bool) (*Collec
 	} else if err != nil {
 		return nil, err
 	}
-	return LoadCollections([]*CollectionConfig{{name, path, path, lock, false, name, "", "", ""}}, os.TempDir())
+	return LoadCollections([]*CollectionConfig{{name, path, path, load, false, name, "", "", ""}}, os.TempDir())
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -34,7 +34,7 @@ func tempHfile(t *testing.T, compress bool, blockSize int, keys [][]byte, values
 		log.Println("###############")
 	}
 
-	r, err := NewReader("demo", fp.Name(), false, testing.Verbose())
+	r, err := NewReader("demo", fp.Name(), CopiedToMem, testing.Verbose())
 	assert.Nil(t, err, "error creating reader:", err)
 
 	s := NewScanner(r)


### PR DESCRIPTION
memlock limits on linux can be annoying and perf looks about as good reading on to heap.
obviously assumes running without swap/page outs.